### PR TITLE
Fix wrong field decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binary
-dynamic-sensor-watcher
+dswatcher
 
 # Vendor packages
 vendor/

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ ifndef GLIDE
 	$(error glide is not installed)
 endif
 	@printf "$(MKL_BLUE)[DEPS]$(MKL_CLR_RESET)  Resolving dependencies\n"
-	@glide update
+	@glide install
 
 clean:
 	rm -f $(BIN)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -31,9 +31,12 @@ type DynamicSensorsWatcherConfig struct {
 		NetflowTopics []string `yaml:"netflow_topics"`
 		LimitsTopics  []string `yaml:"limits_topics"`
 	}
+
 	Decoder struct {
-		ElementID int `yaml:"element_id"`
+		ElementID        int `yaml:"element_id"`
+		OptionTemplateID int `yaml:"option_template_id"`
 	}
+
 	Updater struct {
 		URL            string `yaml:"chef_server_url"`
 		Key            string `yaml:"client_key"`

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,9 +27,9 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/redBorder/dynamic-sensors-watcher/internal/consumer"
-	"github.com/redBorder/dynamic-sensors-watcher/internal/decoder"
-	"github.com/redBorder/dynamic-sensors-watcher/internal/updater"
+	"github.com/redBorder/dswatcher/internal/consumer"
+	"github.com/redBorder/dswatcher/internal/decoder"
+	"github.com/redBorder/dswatcher/internal/updater"
 )
 
 var version string

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -107,6 +107,9 @@ func main() {
 	}
 
 	err = chefUpdater.FetchNodes()
+	if err != nil {
+		logrus.Errorln("Error fetching nodes: " + err.Error())
+	}
 
 	ticker := time.NewTicker(
 		time.Duration(config.Updater.FetchInterval) * time.Second)
@@ -115,7 +118,7 @@ func main() {
 		for range ticker.C {
 			err = chefUpdater.FetchNodes()
 			if err != nil {
-				logrus.Warn("Error fetching nodes: " + err.Error())
+				logrus.Errorln("Error fetching nodes: " + err.Error())
 			}
 		}
 	}()
@@ -165,7 +168,7 @@ func main() {
 
 			err = chefUpdater.UpdateNode(ip, deviceID, obsID)
 			if err != nil {
-				logrus.Warn("Error updating node: " + err.Error())
+				logrus.Warnln("Error updating node: " + err.Error())
 				continue
 			}
 
@@ -208,7 +211,7 @@ func main() {
 			}
 
 			if blocked {
-				logrus.Info("Blocked UUID: " + uuid)
+				logrus.Infoln("Blocked UUID: " + uuid)
 			}
 		}
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -22,7 +22,7 @@ import (
 	"runtime"
 
 	rdkafka "github.com/confluentinc/confluent-kafka-go/kafka"
-	"github.com/redBorder/dynamic-sensors-watcher/internal/consumer"
+	"github.com/redBorder/dswatcher/internal/consumer"
 )
 
 // PrintVersion displays the application version.

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 685094566a9b23abf2e1a8c984b3af04cfca35e70da63a7e01162998daac3a3c
-updated: 2017-03-08T11:15:50.634290162+01:00
+hash: dc160e17c4e94774542958c69c777385562c49d16da58e19e1128a910f1ab4dc
+updated: 2017-03-16T10:43:19.138000078+01:00
 imports:
 - name: github.com/confluentinc/confluent-kafka-go
   version: a9b5c269c66e9a2eb5f195563b2f01e65a84c527
@@ -8,9 +8,10 @@ imports:
 - name: github.com/go-chef/chef
   version: a27a34ded3f4ab05bc5c4def0f61eb10272cc246
 - name: github.com/Sirupsen/logrus
-  version: d26492970760ca5d33129d2d799e34be5c4782eb
+  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/tehmaze/netflow
-  version: 9fe95bba7b553cefdc996a4ea5eae8f0166dddb1
+  version: 3262c0d46619ea505a794c10459d23107dd8b34a
+  repo: https://github.com/Bigomby/netflow.git
   subpackages:
   - ipfix
   - netflow1
@@ -22,7 +23,7 @@ imports:
   - session
   - translate
 - name: golang.org/x/sys
-  version: d67a3279aecd76a65c4c9e6c352c888f5b3a574a
+  version: 99f16d856c9836c42d24e7ab64ea72916925fa97
   subpackages:
   - unix
 - name: gopkg.in/yaml.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,15 +1,12 @@
-package: github.com/redBorder/dynamic-sensors-watcher
+package: github.com/redBorder/dswatcher
 import:
 - package: github.com/confluentinc/confluent-kafka-go
   version: ~0.9.4
   subpackages:
   - kafka
 - package: github.com/tehmaze/netflow
-  subpackages:
-  - ipfix
-  - session
-- package: github.com/go-chef/chef
-  version: a27a34ded3f4ab05bc5c4def0f61eb10272cc246
+  version: 3262c0d46619ea505a794c10459d23107dd8b34a
+  repo: https://github.com/Bigomby/netflow.git
 testImport:
 - package: github.com/smartystreets/goconvey
   version: ~1.6.2

--- a/internal/decoder/netflow_decoder_test.go
+++ b/internal/decoder/netflow_decoder_test.go
@@ -26,7 +26,8 @@ import (
 func TestDecoder(t *testing.T) {
 	Convey("Given a Netflow 10 decoder", t, func() {
 		decoder := NewNetflow10Decoder(Netflow10DecoderConfig{
-			ElementID: 144,
+			ElementID:        300,
+			OptionTemplateID: 258,
 		})
 
 		Convey("For valid template and data sets", func() {
@@ -35,72 +36,123 @@ func TestDecoder(t *testing.T) {
 				// Headers //
 				/////////////
 				0x00, 0x0a, // Version: 10
-				0x00, 0x24, // Length: 36
+				0x00, 0x64, // Length: 100
 				0x58, 0xb0, 0x00, 0x49, // ExportTime: 1487929417
 				0x00, 0x00, 0xc6, 0x5b, // FlowSequence: 50779
 				0x00, 0x00, 0x00, 0x0a, // Observation Domain Id: 10
 
-				////////////////////////////////////////
-				// Set 1 [id=2] (Data Template): 1025 //
-				////////////////////////////////////////
-				0x00, 0x02, // FlowSet Id: Data Template (V10 [IPFIX]) (2)
-				0x00, 0x0c, // FlowSet Length: 12
-				// Template (Id = 1025, Count = 1)
-				0x04, 0x01, // Template Id: 1025
-				0x00, 0x01, // Field Count: 1
-				0x00, 0x90, 0x00, 0x04, // Field (1/1): FLOW_EXPORTER
+				//////////////////////////////////////////
+				// Set 1 [id=3] (Options Template): 258 //
+				//////////////////////////////////////////
+				0x00, 0x03, // FlowSet Id: Options Template (V10 [IPFIX]) (3)
+				0x00, 0x0e, // FlowSet Length: 14
+				// Options Template (Id = 258) (Scope Count = 1; Data Count = 0)
+				0x01, 0x02, // Template Id: 258
+				0x00, 0x01, // Total Field Count: 1
+				0x00, 0x01, // Scope Field Count: 1
+				0x01, 0x2c, 0x00, 0x40, // Field (1/1) [Scope]: observationDomainName
 
-				///////////////////////////////
-				// Set 2 [id=1025] (1 flows) //
-				///////////////////////////////
-				0x04, 0x01, // FlowSet Id: (Data) (1025)
-				0x00, 0x08, // FlowSet Length: 8
-				// Flow 1
-				0x00, 0x00, 0x00, 0x2a, // FlowExporter: 42
+				//////////////////////////////
+				// Set 2 [id=258] (1 flows) //
+				//////////////////////////////
+				0x01, 0x02, // FlowSet Id: (Data) (258)
+				0x00, 0x46, // FlowSet Length: 70
+				// Flow 1: Serial number "tim/88888888"
+				0x74, 0x69, 0x6d, 0x2f, 0x38, 0x38, 0x38, 0x38,
+				0x38, 0x38, 0x38, 0x38, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				// Padding
+				0x00, 0x00,
 			}
 
-			Convey("The id and observation domain ID should be decoded", func() {
-				id, obsID, err := decoder.Decode(3232235777, data)
+			Convey("The serial number and observation domain ID should be decoded", func() {
+				sn, obsID, err := decoder.Decode(3232235777, data) // 192.168.1.1
 				So(err, ShouldBeNil)
-				So(id, ShouldEqual, 42)
+				So(sn, ShouldEqual, "tim/88888888")
 				So(obsID, ShouldEqual, 10)
 			})
 		})
 
-		Convey("For valid template and data sets without FLOW_EXPORTER", func() {
+		Convey("For valid template and data sets with different option template id", func() {
 			data := []byte{
 				/////////////
 				// Headers //
 				/////////////
 				0x00, 0x0a, // Version: 10
-				0x00, 0x24, // Length: 36
+				0x00, 0x64, // Length: 100
 				0x58, 0xb0, 0x00, 0x49, // ExportTime: 1487929417
 				0x00, 0x00, 0xc6, 0x5b, // FlowSequence: 50779
 				0x00, 0x00, 0x00, 0x0a, // Observation Domain Id: 10
 
-				////////////////////////////////////////
-				// Set 1 [id=2] (Data Template): 1025 //
-				////////////////////////////////////////
-				0x00, 0x02, // FlowSet Id: Data Template (V10 [IPFIX]) (2)
-				0x00, 0x0c, // FlowSet Length: 12
-				// Template (Id = 1025, Count = 1)
-				0x04, 0x01, // Template Id: 1025
-				0x00, 0x01, // Field Count: 1
-				0x00, 0x08, 0x00, 0x04, // Field (1/1): IP_SRC_ADDR
+				//////////////////////////////////////////
+				// Set 1 [id=3] (Options Template): 258 //
+				//////////////////////////////////////////
+				0x00, 0x03, // FlowSet Id: Options Template (V10 [IPFIX]) (3)
+				0x00, 0x0e, // FlowSet Length: 14
+				// Options Template (Id = 258) (Scope Count = 1; Data Count = 0)
+				0x01, 0x02, // Template Id: 258
+				0x00, 0x01, // Total Field Count: 1
+				0x00, 0x01, // Scope Field Count: 1
+				0x01, 0x2c, 0x00, 0x40, // Field (1/1) [Scope]: observationDomainName
 
-				///////////////////////////////
-				// Set 2 [id=1025] (1 flows) //
-				///////////////////////////////
-				0x04, 0x01, // FlowSet Id: (Data) (1025)
-				0x00, 0x08, // FlowSet Length: 8
-				// Flow 1
-				0xc8, 0xa8, 0xd4, 0x0e, // SrcAddr: 192.168.212.14
+				//////////////////////////////
+				// Set 2 [id=257] (1 flows) //
+				//////////////////////////////
+				0x01, 0x00, // FlowSet Id: (Data) (257)
+				0x00, 0x46, // FlowSet Length: 70
+				// Flow 1: Serial number "tim/88888888"
+				0x74, 0x69, 0x6d, 0x2f, 0x38, 0x38, 0x38, 0x38,
+				0x38, 0x38, 0x38, 0x38, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				// Padding
+				0x00, 0x00,
 			}
 
-			Convey("The retuned ID should be zero", func() {
+			Convey("The serial number and observation domain ID should NOT be decoded", func() {
+				sn, obsID, err := decoder.Decode(3232235777, data) // 192.168.1.1
+				So(err, ShouldBeNil)
+				So(sn, ShouldEqual, "")
+				So(obsID, ShouldEqual, 10)
+			})
+		})
+
+		Convey("For valid template and data sets without serial number", func() {
+			data := []byte{
+				/////////////
+				// Headers //
+				/////////////
+				0x00, 0x0a, // Version: 10
+				0x00, 0x1e, // Length: 100
+				0x58, 0xb0, 0x00, 0x49, // ExportTime: 1487929417
+				0x00, 0x00, 0xc6, 0x5b, // FlowSequence: 50779
+				0x00, 0x00, 0x00, 0x0a, // Observation Domain Id: 10
+
+				//////////////////////////////////////////
+				// Set 1 [id=3] (Options Template): 258 //
+				//////////////////////////////////////////
+				0x00, 0x03, // FlowSet Id: Options Template (V10 [IPFIX]) (3)
+				0x00, 0x0e, // FlowSet Length: 14
+				// Options Template (Id = 258) (Scope Count = 1; Data Count = 0)
+				0x01, 0x02, // Template Id: 258
+				0x00, 0x01, // Total Field Count: 1
+				0x00, 0x01, // Scope Field Count: 1
+				0x01, 0x2c, 0x00, 0x40, // Field (1/1) [Scope]: observationDomainName
+			}
+
+			Convey("The retuned serial number should be empty", func() {
 				id, obsID, err := decoder.Decode(3232235777, data)
 				So(err, ShouldBeNil)
-				So(id, ShouldEqual, 0)
+				So(id, ShouldEqual, "")
 				So(obsID, ShouldEqual, 10)
 			})
 		})

--- a/internal/updater/chef_updater.go
+++ b/internal/updater/chef_updater.go
@@ -107,9 +107,8 @@ func (cu *ChefUpdater) FetchNodes() error {
 // UpdateNode gets a list of nodes an look for one with the given address. If a
 // node is found will update the deviceID.
 // If a node with the given address is not found an error is returned
-func (cu *ChefUpdater) UpdateNode(address net.IP, deviceID, obsID uint32) error {
-	deviceIDStr := strconv.FormatUint(uint64(deviceID), 10)
-	node, err := findNode(cu.DeviceIDPath, deviceIDStr, cu.nodes)
+func (cu *ChefUpdater) UpdateNode(address net.IP, serialNumber string, obsID uint32) error {
+	node, err := findNode(cu.DeviceIDPath, serialNumber, cu.nodes)
 	if err != nil {
 		return err
 	}

--- a/internal/updater/chef_updater.go
+++ b/internal/updater/chef_updater.go
@@ -118,10 +118,6 @@ func (cu *ChefUpdater) UpdateNode(address net.IP, deviceID, obsID uint32) error 
 		return errors.New("Node not found")
 	}
 
-	if node == nil {
-		return errors.New("Node not found")
-	}
-
 	attributes, err := getAttributes(node.NormalAttributes, cu.DeviceIDPath)
 	if err != nil {
 		return err


### PR DESCRIPTION
The correct field belongs to an option template instead a data template.

The configuration also needs to specify the `option_template_id` that should be decoded in order to look up for the field containing the serial number.

---

Closes #15 