### PR TITLE
Decode deviceID

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -33,8 +33,9 @@ type DynamicSensorsWatcherConfig struct {
 	}
 
 	Decoder struct {
-		ElementID        int `yaml:"element_id"`
-		OptionTemplateID int `yaml:"option_template_id"`
+		ElementID           int `yaml:"element_id"`
+		DeviceTypeElementID int `yaml:"device_type_element_id"`
+		OptionTemplateID    int `yaml:"option_template_id"`
 	}
 
 	Updater struct {
@@ -46,6 +47,7 @@ type DynamicSensorsWatcherConfig struct {
 		IPAddressPath     string `yaml:"ipaddress_path"`
 		SensorUUIDPath    string `yaml:"sensor_uuid_path"`
 		BlocketStatusPath string `yaml:"blocked_status_path"`
+		DeviceIDPath      string `yaml:"device_id_path"`
 		UpdateInterval    int64  `yaml:"update_interval_s"`
 		FetchInterval     int64  `yaml:"fetch_interval_s"`
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -81,6 +81,7 @@ func main() {
 
 	decoderConfig := decoder.Netflow10DecoderConfig{
 		SerialNumberElementID: uint16(config.Decoder.ElementID),
+		DeviceTypeElementID:   uint16(config.Decoder.DeviceTypeElementID),
 		OptionTemplateID:      uint16(config.Decoder.OptionTemplateID),
 	}
 	nfDecoder := decoder.NewNetflow10Decoder(decoderConfig)
@@ -103,6 +104,7 @@ func main() {
 		ObservationIDPath: config.Updater.ObservationIDPath,
 		IPAddressPath:     config.Updater.IPAddressPath,
 		BlockedStatusPath: config.Updater.BlocketStatusPath,
+		DeviceIDPath:      config.Updater.DeviceIDPath,
 	})
 	if err != nil {
 		logrus.Fatal("Error creating Chef API client: " + err.Error())
@@ -167,7 +169,12 @@ func main() {
 
 			lastUpdated[sensor.SerialNumber] = time.Now()
 
-			err = chefUpdater.UpdateNode(ip, sensor.SerialNumber, sensor.ObservationID)
+			err = chefUpdater.UpdateNode(
+				ip,
+				sensor.SerialNumber,
+				sensor.ObservationID,
+				sensor.DeviceID,
+			)
 			if err != nil {
 				logrus.Warnf("Error updating node [%s | %s]: %s",
 					sensor.SerialNumber, ip.String(), err.Error())

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -80,8 +80,8 @@ func main() {
 	//////////////////////
 
 	decoderConfig := decoder.Netflow10DecoderConfig{
-		ElementID:        uint16(config.Decoder.ElementID),
-		OptionTemplateID: uint16(config.Decoder.OptionTemplateID),
+		SerialNumberElementID: uint16(config.Decoder.ElementID),
+		OptionTemplateID:      uint16(config.Decoder.OptionTemplateID),
 	}
 	nfDecoder := decoder.NewNetflow10Decoder(decoderConfig)
 
@@ -147,36 +147,36 @@ func main() {
 		lastUpdated := make(map[string]time.Time)
 
 		for message := range nfMessages {
-			serialNumber, obsID, err := nfDecoder.Decode(message.IP, message.Data)
+			sensor, err := nfDecoder.Decode(message.IP, message.Data)
 			if err != nil {
 				logrus.Errorln("Error decoding netflow: " + err.Error())
+				continue
+			}
+
+			if sensor == nil {
 				continue
 			}
 
 			ip := make(net.IP, 4)
 			binary.BigEndian.PutUint32(ip, message.IP)
 
-			if len(serialNumber) == 0 {
-				continue
-			}
-
-			if time.Since(lastUpdated[serialNumber]) <
+			if time.Since(lastUpdated[sensor.SerialNumber]) <
 				time.Duration(config.Updater.UpdateInterval)*time.Second {
 				continue
 			}
 
-			lastUpdated[serialNumber] = time.Now()
+			lastUpdated[sensor.SerialNumber] = time.Now()
 
-			err = chefUpdater.UpdateNode(ip, serialNumber, obsID)
+			err = chefUpdater.UpdateNode(ip, sensor.SerialNumber, sensor.ObservationID)
 			if err != nil {
 				logrus.Warnf("Error updating node [%s | %s]: %s",
-					serialNumber, ip.String(), err.Error())
+					sensor.SerialNumber, ip.String(), err.Error())
 				continue
 			}
 
 			logrus.Infof(
 				"Updated sensor [IP: %s | SERIAL_NUMBER: %s | OBS. Domain ID: %d]",
-				ip.String(), serialNumber, obsID)
+				ip.String(), sensor.SerialNumber, sensor.ObservationID)
 		}
 
 		wg.Done()

--- a/internal/decoder/netflow_decoder.go
+++ b/internal/decoder/netflow_decoder.go
@@ -19,7 +19,9 @@ package decoder
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
+	"net"
 
 	"github.com/tehmaze/netflow"
 	"github.com/tehmaze/netflow/ipfix"
@@ -30,19 +32,29 @@ import (
 // Netflow10Decoder //
 //////////////////////
 
+// Sensor struct contains information about a sensor that has been detected
+type Sensor struct {
+	SerialNumber  string
+	ObservationID uint32
+	Address       net.IP
+	DeviceID      uint32
+}
 type decoders map[uint32]*netflow.Decoder
+type sensors []Sensor
 
 // Netflow10DecoderConfig contains the Netflow10Decoder configuration
 type Netflow10DecoderConfig struct {
-	ElementID        uint16
-	OptionTemplateID uint16
+	DeviceTypeElementID   uint16
+	SerialNumberElementID uint16
+	OptionTemplateID      uint16
 }
 
 // Netflow10Decoder decode a serial number and IP address from Netflow data
 type Netflow10Decoder struct {
 	Netflow10DecoderConfig
 
-	d decoders
+	sensors  sensors
+	decoders decoders
 }
 
 // NewNetflow10Decoder creates a new instance of a NetflowDecoder
@@ -50,41 +62,51 @@ func NewNetflow10Decoder(config Netflow10DecoderConfig) *Netflow10Decoder {
 	return &Netflow10Decoder{
 		Netflow10DecoderConfig: config,
 
-		d: make(map[uint32]*netflow.Decoder),
+		decoders: make(map[uint32]*netflow.Decoder),
 	}
 }
 
 // Decode tries to decode a netflow packet. The decoder maintains a session for
 // ever IP address so devices using different IP address can reuse templates.
-// Once a NF10/IPFIX packet is decoded, Decode tries to find a device ID.
-// If no device ID has been found the returned value is zero.
-func (nd Netflow10Decoder) Decode(ip uint32, data []byte) (string, uint32, error) {
-	decoder, found := nd.d[ip]
+// Once a NF10/IPFIX packet is decoded, Decode tries to find a serial number.
+// If no serial number has been found the returned value is zero.
+func (nd *Netflow10Decoder) Decode(ip uint32, data []byte) (*Sensor, error) {
+	decoder, found := nd.decoders[ip]
 	if !found {
 		decoder = netflow.NewDecoder(session.New())
-		nd.d[ip] = decoder
+		nd.decoders[ip] = decoder
 	}
 
 	m, err := decoder.Read(bytes.NewBuffer(data))
 	if err != nil {
-		return "", 0, errors.New("Error decoding packet: " + err.Error())
+		return nil, errors.New("Error decoding packet: " + err.Error())
 	}
 
 	p, ok := m.(*ipfix.Message)
 	if !ok {
-		return "", 0, errors.New("Invalid message received: Message is not NF10/IPFIX")
+		return nil, errors.New("Invalid message received: Message is not NF10/IPFIX")
 	}
 
 	for _, ots := range p.OptionsTemplateSets {
 		for _, record := range ots.Records {
 			if record.TemplateID == nd.OptionTemplateID {
 				if ok := len(record.ScopeFields) == 1; ok {
-					if record.ScopeFields[0].InformationElementID == nd.ElementID {
+					if record.ScopeFields[0].InformationElementID == nd.SerialNumberElementID {
 						if ok := len(p.DataSets) == 1 && p.DataSets[0].Header.ID == nd.OptionTemplateID; ok {
 							n := bytes.Index(p.DataSets[0].Bytes, []byte{0})
-							serialNumer := string(p.DataSets[0].Bytes[:n])
+							s := Sensor{
+								SerialNumber:  string(p.DataSets[0].Bytes[:n]),
+								ObservationID: p.Header.ObservationDomainID,
+							}
 
-							return serialNumer, p.Header.ObservationDomainID, nil
+							if nd.DeviceTypeElementID != 0 {
+								s.Address = make(net.IP, 4)
+								binary.BigEndian.PutUint32(s.Address, ip)
+								nd.sensors = append(nd.sensors, s)
+								return nil, nil
+							}
+
+							return &s, nil
 						}
 					}
 				}
@@ -92,5 +114,28 @@ func (nd Netflow10Decoder) Decode(ip uint32, data []byte) (string, uint32, error
 		}
 	}
 
-	return "", p.Header.ObservationDomainID, nil
+	if nd.DeviceTypeElementID != 0 {
+		for _, ds := range p.DataSets {
+			for _, record := range ds.Records {
+				for _, field := range record.Fields {
+					if field.Translated.InformationElementID == nd.DeviceTypeElementID {
+						for _, sensor := range nd.sensors {
+							address := make(net.IP, 4)
+							binary.BigEndian.PutUint32(address, ip)
+							if sensor.Address.Equal(address) &&
+								sensor.ObservationID == p.Header.ObservationDomainID {
+
+								sensor.DeviceID = field.Translated.Value.(uint32)
+								if sensor.SerialNumber != "" {
+									return &sensor, nil
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return nil, nil
 }


### PR DESCRIPTION
- [x] When decoding sensors NetflowData, not only decode the Serial Number, and Observation Domain ID, but also decode the Exporting Process ID so it could be verified.
- [x] Check that the device id from the Netflow data matches the device ID stored on the database (chef).
---

Closes #19 
Closes #21 