### PR TITLE
:sparkles: Only block generic sensors

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,6 +33,8 @@ import (
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 )
 
+const genericProductType = 999
+
 var (
 	version    string
 	configFile string
@@ -246,7 +248,7 @@ func main() {
 					lastBlocked = time.Now()
 					org := string(m)
 
-					errs := chefUpdater.BlockOrganization(org)
+					errs := chefUpdater.BlockOrganization(org, genericProductType)
 					if err != nil {
 						for _, err := range errs {
 							log.Warnf("Error blocking sensor %s: %s", org, err.Error())


### PR DESCRIPTION
When blocking sensors, only generic sensors (product type = 999) should be blocked.