### PR TITLE
Feature/block license/#34

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -49,6 +49,9 @@ type DynamicSensorsWatcherConfig struct {
 		BlockedStatusPath    string `yaml:"blocked_status_path"`
 		ProductTypePath      string `yaml:"product_type_path"`
 		OrganizationUUIDPath string `yaml:"organization_uuid_path"`
+		LicenseUUIDPath      string `yaml:"license_uuid_path"`
+		DataBagName          string `yaml:"data_bag_name"`
+		DataBagItem          string `yaml:"data_bag_item"`
 		UpdateInterval       int64  `yaml:"update_interval_s"`
 		FetchInterval        int64  `yaml:"fetch_interval_s"`
 	}

--- a/internal/consumer/consumer.go
+++ b/internal/consumer/consumer.go
@@ -20,8 +20,11 @@ package consumer
 // Message can be either an UUID to be blocked or a ResetSignal
 type Message interface{}
 
-// UUID identifies the sensor that reached the limit
-type UUID string
+// BlockOrganization identifies the organization that reached the limit
+type BlockOrganization string
+
+// BlockLicense identifies the license that has expired
+type BlockLicense string
 
 // ResetSignal notifies that sensors from a given organization should be
 // unblocked.
@@ -38,5 +41,5 @@ type FlowData struct {
 // NetflowConsumer gets an IP address and Netflow data from a resource
 type NetflowConsumer interface {
 	ConsumeNetflow() (messages chan FlowData, events chan string)
-	ConsumeLimits() (messages chan UUID, events chan string)
+	ConsumeLimits() (messages chan Message, events chan string)
 }

--- a/internal/consumer/kafka_consumer.go
+++ b/internal/consumer/kafka_consumer.go
@@ -143,7 +143,10 @@ func (kc *KafkaConsumer) ConsumeLimits() (chan Message, chan string) {
 
 			switch data.Type {
 			case "limit_reached":
-				messages <- UUID(data.UUID)
+				messages <- BlockOrganization(data.UUID)
+
+			case "license_expired":
+				messages <- BlockLicense(data.UUID)
 
 			case "counters_reset":
 				messages <- ResetSignal{

--- a/internal/consumer/kafka_consumer_test.go
+++ b/internal/consumer/kafka_consumer_test.go
@@ -320,7 +320,7 @@ func TestLimitsConsumer(t *testing.T) {
 				messages, _ := consumer.ConsumeLimits()
 				msg := <-messages
 
-				uuid, ok := msg.(UUID)
+				uuid, ok := msg.(BlockOrganization)
 				So(ok, ShouldBeTrue)
 				So(uuid, ShouldEqual, "7416ba90-926b-475f-a26e-53fe1a7e3c36")
 

--- a/internal/updater/chef_updater_test.go
+++ b/internal/updater/chef_updater_test.go
@@ -108,40 +108,6 @@ func TestFindNode(t *testing.T) {
 	assert.Nil(t, node)
 }
 
-func TestBlockSensors(t *testing.T) {
-	chefUpdater, err := NewChefUpdater(ChefUpdaterConfig{
-		AccessKey:         testPEMKey,
-		Name:              "test",
-		SensorUUIDPath:    "org/uuid",
-		BlockedStatusPath: "org/blocked",
-	})
-	assert.NoError(t, err)
-
-	chefUpdater.nodes = bootstrapSensorsDB()
-
-	blocked, err := chefUpdater.BlockSensor("0000")
-	assert.NoError(t, err)
-	attributes, err := getParent(
-		chefUpdater.nodes["0"].NormalAttributes,
-		chefUpdater.BlockedStatusPath)
-	assert.NoError(t, err)
-	assert.True(t, attributes["blocked"].(bool))
-	assert.True(t, blocked)
-
-	blocked, err = chefUpdater.BlockSensor("0000")
-	assert.NoError(t, err)
-	attributes, err = getParent(
-		chefUpdater.nodes["0"].NormalAttributes,
-		chefUpdater.BlockedStatusPath)
-	assert.NoError(t, err)
-	assert.True(t, attributes["blocked"].(bool))
-	assert.False(t, blocked)
-
-	blocked, err = chefUpdater.BlockSensor("7777")
-	assert.Error(t, err)
-	assert.False(t, blocked)
-}
-
 func TestBlockOrganization(t *testing.T) {
 	chefUpdater, err := NewChefUpdater(ChefUpdaterConfig{
 		AccessKey:            testPEMKey,


### PR DESCRIPTION
When a `license_expired` signal is received, all the sensors associated to the expired license are blocked.